### PR TITLE
Enable SSL on mongodb chart

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 [*.md]
 charset = utf-8
 trim_trailing_whitespace = false
+
+[*.yaml]
+quote_type = single

--- a/charts/mongodb/v0.1.0/questions.yaml
+++ b/charts/mongodb/v0.1.0/questions.yaml
@@ -113,6 +113,13 @@ questions:
     show_if: config.shardTopology.enabled=false
     label: 'replica set enabled'
     group: Config
+  - variable: config.ssl.enabled
+    default: false
+    description: ''
+    type: boolean
+    required: true
+    label: 'ssl enabled'
+    group: Config
   - variable: config.replicaSet.replicas
     default: 3
     description: ''

--- a/charts/mongodb/v0.1.0/questions.yaml
+++ b/charts/mongodb/v0.1.0/questions.yaml
@@ -2,8 +2,7 @@ categories:
   - Backup
   - Database
 questions:
-
-# Config
+  # Config
   - variable: config.clusterProvider
     default: infrastructure
     description: ''
@@ -296,7 +295,7 @@ questions:
     label: 'custom config'
     group: Config
 
-# Mongo Express
+  # Mongo Express
   - variable: config.mongoExpress.enabled
     default: true
     description: ''
@@ -321,7 +320,7 @@ questions:
         label: 'mongo express password'
         group: 'Mongo Express'
 
-# Persistence
+  # Persistence
   - variable: persistence.enabled
     default: false
     description: ''
@@ -432,7 +431,7 @@ questions:
         show_if: persistence.stash.enabled=true
         label: 'stash restore snapshot'
 
-# Services and Load Balancing
+  # Services and Load Balancing
   - variable: ingress.mongoExpress.enabled
     default: true
     description: ''
@@ -524,7 +523,7 @@ questions:
         max: 32767
         label: 'mongodb port'
 
-# Images
+  # Images
   - variable: images.mongo_express.repository
     default: mongo-express
     description: ''

--- a/charts/mongodb/v0.1.0/templates/mongodb.yaml
+++ b/charts/mongodb/v0.1.0/templates/mongodb.yaml
@@ -16,8 +16,14 @@ spec:
   monitor:
     agent: prometheus.io/builtin
   {{- end }}
+  {{- if .Values.config.ssl.enabled }}
+  sslMode: requireSSL
+  {{- else }}
   sslMode: disabled
-  # clusterAuthMode: x509
+  {{- end }}
+  {{- if (and .Values.config.ssl.enabled .Values.config.replicaSet.enabled) }}
+  clusterAuthMode: x509
+  {{- end }}
   {{- if .Values.persistence.enabled }}
   storageType: Durable
   {{- else }}

--- a/charts/mongodb/v0.1.0/values.yaml
+++ b/charts/mongodb/v0.1.0/values.yaml
@@ -5,7 +5,7 @@ images:
 
 config:
   clusterProvider: infrastructure
-  customConfig: ''
+  customConfig: ""
   imagePullPolicy: IfNotPresent
   password: p@ssw0rd
   pause: true
@@ -47,6 +47,8 @@ config:
   replicaSet:
     enabled: false
     replicas: 3
+  ssl:
+    enabled: false
   shardTopology:
     enabled: false
     configServer:
@@ -83,18 +85,18 @@ service:
     type: NodePort
     externalTrafficPolicy: Cluster
     nodePorts:
-      http: ''
+      http: ""
   mongodb:
     type: ClusterIP
     externalTrafficPolicy: Cluster
     nodePorts:
-      mongodb: ''
+      mongodb: ""
 
 ingress:
   mongoExpress:
-    certificate: ''
+    certificate: ""
     enabled: false
-    hostname: ''
+    hostname: ""
     path: /
     tls: false
     issuer:
@@ -107,24 +109,24 @@ issuer:
 persistence:
   accessMode: ReadWriteOnce
   enabled: false
-  existingClaim: ''
+  existingClaim: ""
   size: 1Gi
-  storageClass: ''
+  storageClass: ""
   velero:
     enabled: false
   stash:
-    bucket: ''
-    container: ''
+    bucket: ""
+    container: ""
     enabled: false
     endpoint: s3.amazonaws.com
     keepLast: 30
     paused: false
     prefix: stash
-    schedule: '0 0 * * *'
+    schedule: "0 0 * * *"
     secret: stash-config-stash-config
     type: s3
     restore:
-      snapshot: ''
+      snapshot: ""
 
 probes:
   liveness:

--- a/charts/mongodb/v0.1.0/values.yaml
+++ b/charts/mongodb/v0.1.0/values.yaml
@@ -5,7 +5,7 @@ images:
 
 config:
   clusterProvider: infrastructure
-  customConfig: ""
+  customConfig: ''
   imagePullPolicy: IfNotPresent
   password: p@ssw0rd
   pause: true
@@ -85,18 +85,18 @@ service:
     type: NodePort
     externalTrafficPolicy: Cluster
     nodePorts:
-      http: ""
+      http: ''
   mongodb:
     type: ClusterIP
     externalTrafficPolicy: Cluster
     nodePorts:
-      mongodb: ""
+      mongodb: ''
 
 ingress:
   mongoExpress:
-    certificate: ""
+    certificate: ''
     enabled: false
-    hostname: ""
+    hostname: ''
     path: /
     tls: false
     issuer:
@@ -109,24 +109,24 @@ issuer:
 persistence:
   accessMode: ReadWriteOnce
   enabled: false
-  existingClaim: ""
+  existingClaim: ''
   size: 1Gi
-  storageClass: ""
+  storageClass: ''
   velero:
     enabled: false
   stash:
-    bucket: ""
-    container: ""
+    bucket: ''
+    container: ''
     enabled: false
     endpoint: s3.amazonaws.com
     keepLast: 30
     paused: false
     prefix: stash
-    schedule: "0 0 * * *"
+    schedule: '0 0 * * *'
     secret: stash-config-stash-config
     type: s3
     restore:
-      snapshot: ""
+      snapshot: ''
 
 probes:
   liveness:


### PR DESCRIPTION
Enables ssl support for mongodb.

See docs here:  https://kubedb.com/docs/v0.13.0-rc.0/guides/mongodb/tls-ssl-encryption/tls-ssl-encryption/